### PR TITLE
Refactor Videos component to display video directly

### DIFF
--- a/src/sections/Videos.css
+++ b/src/sections/Videos.css
@@ -28,28 +28,14 @@
   overflow: hidden;
 }
 
-.video-thumbnail img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: opacity 0.3s ease;
-}
-
 .video-overlay {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.video-item:hover .video-thumbnail img {
   opacity: 0.7;
+  transition: opacity 0.3s ease;
 }
 
 .video-item:hover .video-overlay {

--- a/src/sections/Videos.jsx
+++ b/src/sections/Videos.jsx
@@ -16,13 +16,6 @@ const Videos = () => {
     threshold: 0.1,
   });
   
-
-  // useEffect(() => {
-  //   if (inView) {
-  //     ref.current.classList.add('is-visible');
-  //   }
-  // }, [inView, ref]);
-
   return (
     <section id="videos" className={`videos animate-on-scroll ${inView ? 'is-visible' : ''}`}  ref={ref}>
       <h2>Videos</h2>
@@ -30,10 +23,7 @@ const Videos = () => {
         {videos.map((video) => (
           <div key={video.id} className="video-item">
             <div className="video-thumbnail">
-              <img
-                src={`https://img.youtube.com/vi/${video.id}/0.jpg`}
-                alt={video.title}
-              />
+
               <div className="video-overlay">
                 <iframe
                   width="100%"


### PR DESCRIPTION
- Removed the thumbnail image from the video-thumbnail div to allow the video to be displayed directly.
- Simplified the video item structure for improved clarity and performance.